### PR TITLE
templateのイメージをGHCRにプッシュするGitHub Actionsを追加

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+  pull_request: null # ToDo: delete
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=ghcr.io/mixigroup/techbookfest
+          TAGS="${DOCKER_IMAGE}:latest"
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:${GITHUB_REF#refs/tags/v}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          version: latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./template/manifest
+          file: ./template/manifest/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/386
+          tags: ${{ steps.prep.outputs.tags }}
+          push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,9 @@ name: Publish Docker image
 on:
   release:
     types: [published]
-  pull_request: null # ToDo: delete
+  push:
+    branches:
+    - master
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -1,4 +1,4 @@
-name: build docker image and exec review
+name: Exec Re:VIEW
 on:
   pull_request: null
   push:
@@ -6,10 +6,13 @@ on:
     - master
 jobs:
   build:
+    name: Build Docker image and exec Re:VIEW
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
     - name: Build docker image
       run: docker build -t techbookfest template/manifest
+
     - name: Exec Re:VIEW with docker image
       run: docker run --rm -v `pwd`/template:/work/tmp -w /work/tmp techbookfest /bin/sh -c "textlint *.re && review-pdfmaker config.yml"


### PR DESCRIPTION
template の Docker Image を GItHub Actions を使って GitHub Container Registry にプッシュします。

ついでに既存の GitHub Actions の設定もリファクタリングしてる

### 参考
- https://docs.github.com/en/actions/language-and-framework-guides/publishing-docker-images#publishing-images-to-github-packages
- https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#updating-your-github-actions-workflow
- https://github.com/docker/build-push-action