### PR TITLE
技術書典13での修正

### DIFF
--- a/template/prh.yaml
+++ b/template/prh.yaml
@@ -2629,9 +2629,9 @@ rules:
   - expected: MiniMagick
     pattern:  /\bMiniMagick\b/i
   - expected: MIXI
-    pattern:  /\b[^SNS「]mixi[^」)]\b/i
-  - expected: MIXI
-    pattern:  /ミクシィ/
+    pattern:  
+      - /\b(?!SNS「)mixi(?!」)\b/
+      - /ミクシィ/
   - expected: MongoDB
     pattern:  /\bMongo DB\b/
   - expected: msysGit

--- a/template/prh.yaml
+++ b/template/prh.yaml
@@ -1768,6 +1768,8 @@ rules:
     pattern:
       - /cache(?![^a-zA-Z\-])/
       - /Cache(?![^a-zA-Z\-])/
+  - expected: キャラクター
+    pattern:  /キャラクタ[^ー]/
   - expected: クエリ文字列
     pattern:
       - QueryString
@@ -2626,8 +2628,10 @@ rules:
     pattern:  /\bMigemo\b/i
   - expected: MiniMagick
     pattern:  /\bMiniMagick\b/i
-  - expected: mixi
-    pattern:  /\bmixi\b/i
+  - expected: MIXI
+    pattern:  /\b[^SNS「]mixi[^」)]\b/i
+  - expected: MIXI
+    pattern:  /ミクシィ/
   - expected: MongoDB
     pattern:  /\bMongo DB\b/
   - expected: msysGit


### PR DESCRIPTION
・社名変更に伴いmixi, ミクシィをMIXIに
　・SNS「mixi」は除く
・キャラクタをキャラクターに