### PR TITLE
ビルドするイメージの platform を vvakame/review と揃える

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,6 @@
 name: Publish Docker image
 on:
+  pull_request: null
   release:
     types: [published]
   push:
@@ -25,14 +26,9 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -42,11 +38,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: ./template/manifest
           file: ./template/manifest/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/386
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.prep.outputs.tags }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
#24 のエラーの原因はバージョンの問題じゃなくて、ベースイメージに使っている vvakame/review が platforms に linux/amd64 と linux/arm64 を指定していたためだった。

なので、同じようにした。

ついでに、PR でもビルドまでをするようにした。